### PR TITLE
Escape String: Connection Name Param

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -246,7 +246,7 @@ func (cfg *Config) FormatDSN() string {
 			hasParam = true
 			buf.WriteString("?connectionName=")
 		}
-		buf.WriteString(cfg.ConnectionName)
+		buf.WriteString(url.QueryEscape(cfg.ConnectionName))
 	}
 
 	if cfg.MaxRetry > 0 {
@@ -631,8 +631,9 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 
 		// Connection name
 		case "connectionName":
-			cfg.ConnectionName = value
-			return nil
+			if cfg.ConnectionName, err = url.QueryUnescape(value); err != nil {
+				return
+			}
 
 		default:
 			// lazy init

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -48,6 +48,9 @@ var testDSNs = []struct {
 	"user:password@tcp(localhost:5555)/dbname?connectionName=dummy-name",
 	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "localhost:5555", DBName: "dbname", Collation: "utf8_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, ConnectionName: "dummy-name", Intervaler: newExponentialBackoff()},
 }, {
+	"user:password@tcp(localhost:5555)/dbname?connectionName=dummy-name&enableCircuitBreaker=true",
+	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "localhost:5555", DBName: "dbname", Collation: "utf8_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, ConnectionName: "dummy-name", EnableCircuitBreaker: true, Intervaler: newExponentialBackoff()},
+}, {
 	"user:password@tcp(localhost:5555)/dbname?charset=utf8mb4,utf8&tls=skip-verify",
 	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "localhost:5555", DBName: "dbname", Params: map[string]string{"charset": "utf8mb4,utf8"}, Collation: "utf8_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, TLSConfig: "skip-verify", Intervaler: newExponentialBackoff()},
 }, {


### PR DESCRIPTION
### Description
- escape connectionName in param
- unescape again when setting the value

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
