### PR TITLE
support opentracing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A MySQL-Driver for Go's [database/sql](https://golang.org/pkg/database/sql/) pac
   * Secure `LOAD DATA LOCAL INFILE` support with file Whitelisting and `io.Reader` support
   * Optional `time.Time` parsing
   * Optional placeholder interpolation
+  * Support OpenTracing when run mysql-drive with `BeginTx`
 
 ## Requirements
   * Go 1.7 or higher. We aim to support the 3 latest versions of Go.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A MySQL-Driver for Go's [database/sql](https://golang.org/pkg/database/sql/) pac
   * Secure `LOAD DATA LOCAL INFILE` support with file Whitelisting and `io.Reader` support
   * Optional `time.Time` parsing
   * Optional placeholder interpolation
-  * Support OpenTracing when run mysql-drive with `BeginTx`
+  * Support OpenTracing - go-mysql-driver will trace every database operation using OpenTracing API.
 
 ## Requirements
   * Go 1.7 or higher. We aim to support the 3 latest versions of Go.

--- a/connection.go
+++ b/connection.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // a copy of context.Context for Go 1.7 and earlier
@@ -46,8 +48,9 @@ type mysqlConn struct {
 	watcher  chan<- mysqlContext
 	closech  chan struct{}
 	finished chan<- struct{}
-	canceled atomicError // set non-nil if conn is canceled
-	closed   atomicBool  // set when conn is closed, before closech is closed
+	canceled atomicError      // set non-nil if conn is canceled
+	closed   atomicBool       // set when conn is closed, before closech is closed
+	span     opentracing.Span // add span for tracer
 }
 
 // Handles parameters set in DSN after the connection is established

--- a/packets.go
+++ b/packets.go
@@ -163,6 +163,27 @@ func (mc *mysqlConn) writePacketUsingRetry(data []byte) error {
 	return err
 }
 
+func (mc *mysqlConn) tracePacket(command []byte, err error) {
+	span := mc.span
+	if span == nil {
+		return
+	}
+	defer span.Finish()
+
+	start := time.Now()
+	span = span.SetTag("db.type", "mysql")
+	span = span.SetTag("db.query", string(command))
+	span = span.SetTag("span.kind", "client")
+	if err != nil {
+		span.LogEvent("error")
+		span.LogKV(
+			"event", "error",
+			"message", err.Error(),
+			"latency", time.Since(start).Seconds(),
+		)
+	}
+}
+
 func (mc *mysqlConn) writePacketUsingCB(data []byte) error {
 	var err error
 	for i := 0; i <= mc.cfg.MaxRetry; i++ {
@@ -190,11 +211,15 @@ func (mc *mysqlConn) writePacketUsingCB(data []byte) error {
 }
 
 // Write packet buffer 'data'
-func (mc *mysqlConn) writePacket(data []byte) error {
+func (mc *mysqlConn) writePacket(data []byte) (err error) {
 	if mc.cfg.EnableCircuitBreaker {
-		return mc.writePacketUsingCB(data)
+		err = mc.writePacketUsingCB(data)
+	} else {
+		err = mc.writePacketUsingRetry(data)
 	}
-	return mc.writePacketUsingRetry(data)
+
+	mc.tracePacket(data, err)
+	return
 }
 
 /******************************************************************************

--- a/packets.go
+++ b/packets.go
@@ -19,6 +19,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/afex/hystrix-go/hystrix"
 )
 
@@ -164,9 +166,11 @@ func (mc *mysqlConn) writePacketUsingRetry(data []byte) error {
 }
 
 func (mc *mysqlConn) tracePacket(command []byte, err error) {
-	span := mc.span
-	if span == nil {
-		return
+	var span opentracing.Span
+	if mc.span == nil {
+		span = opentracing.StartSpan("mysql_tracing")
+	} else {
+		span = mc.span
 	}
 	defer span.Finish()
 


### PR DESCRIPTION
### Description
support opentracing API

### Checklist
- [x] add support OpenTracing API
- [x]  go-mysql-driver will trace every database operation using OpenTracing API.
